### PR TITLE
Remove link to outdated GovCloud info

### DIFF
--- a/jobs/uaa-customized/templates/govcloud/web/login.html
+++ b/jobs/uaa-customized/templates/govcloud/web/login.html
@@ -4,9 +4,6 @@
     <!--  This h1 is set to `.hidden` now, but that may be an acessibility problem.
     IDK what the most useful h1 would be for accessibility, I've added a simple one here. -->
     <h1 th:text="${T(org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder).uaa ? 'Welcome!':'Welcome to '+zone_name+'!'}" class="hidden">Sign in to cloud.gov</h1>
-    <div class="island">
-        <p>GovCloud environment (<a href="https://cloud.gov/docs/apps/govcloud/">what's this?</a>)</p>
-    </div>
 
     <div class="island-content">
         <div class="card notice js-notice">


### PR DESCRIPTION
So that we can remove that page: https://github.com/18F/cg-site/issues/896