### PR TITLE
Run uaa pre-start before customization post-start.

### DIFF
--- a/jobs/uaa-customized/templates/post-start
+++ b/jobs/uaa-customized/templates/post-start
@@ -1,4 +1,8 @@
 #!/bin/bash
 set -e
 
+# Recopy artifacts from /var/vcap/packages/uaa to /var/vcap/data/uaa
+/var/vcap/jobs/uaa/bin/pre-start
+
+# Restart uaa to apply template overrides
 /var/vcap/bosh/bin/monit restart uaa


### PR DESCRIPTION
As of uaa-release v52, uaa artifacts are copied from
/var/vcap/packages/uaa to /var/vcap/data/uaa on pre-start instead of
startup. To apply customizations, manually run pre-start before
restarting uaa in the customization post-start.