### PR TITLE
Wait for uaa to stop and start after updating templates.

### DIFF
--- a/jobs/uaa-customized/templates/post-start
+++ b/jobs/uaa-customized/templates/post-start
@@ -6,3 +6,26 @@ set -e
 
 # Restart uaa to apply template overrides
 /var/vcap/bosh/bin/monit restart uaa
+
+wait_down() {
+  for _ in {1..36}; do
+    if ! curl -fk https://localhost:8443; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+wait_up() {
+  for _ in {1..36}; do
+    if curl -fk https://localhost:8443; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+wait_down
+wait_up


### PR DESCRIPTION
Hopefully @LinuxBozo can make my bash prettier, but this seems to do the right thing:
* Restart uaa
* Wait for uaa to *stop* responding (since monit doesn't always stop uaa right away)
* Wait for uaa to *start* responding