### PR TITLE
Bump UAA restart timeout.

### DIFF
--- a/jobs/uaa-customized/templates/post-start
+++ b/jobs/uaa-customized/templates/post-start
@@ -8,7 +8,7 @@ set -e
 /var/vcap/bosh/bin/monit restart uaa
 
 wait_down() {
-  for _ in {1..36}; do
+  for _ in {1..120}; do
     if ! curl -fk https://localhost:8443; then
       return 0
     fi
@@ -18,7 +18,7 @@ wait_down() {
 }
 
 wait_up() {
-  for _ in {1..36}; do
+  for _ in {1..120}; do
     if curl -fk https://localhost:8443; then
       return 0
     fi


### PR DESCRIPTION
UAA doesn't reliably restart in 36 * 5 / 60 = 3m. Wait up to 10m
instead.