### PR TITLE
Fix pre-start race condition.

### DIFF
--- a/jobs/uaa-customized/templates/pre-start
+++ b/jobs/uaa-customized/templates/pre-start
@@ -9,6 +9,13 @@ set -e
 PACKAGES_DIR=/var/vcap/packages
 JOB_DIR=/var/vcap/jobs/uaa-customized
 
+# Wait until UAA pre-start has finished copying files from packages to avoid
+# race condition between pre-start scripts
+until [ -d /var/vcap/data/uaa/ ]; do
+  sleep 1
+done
+sleep 5
+
 # Allow for > 128bit encryption
 cp -a "${PACKAGES_DIR}"/jce-policy/UnlimitedJCEPolicyJDK8/*.jar "${PACKAGES_DIR}/uaa/jdk/jre/lib/security"
 


### PR DESCRIPTION
Bosh can run pre-start scripts in parallel, so the uaa-customized
pre-start script can modify files in packages while the uaa pre-start
script is copying the same files from packages to data. To avoid the
race condition, wait until data path exists, then wait five seconds
longer for good measure.

h/t @LinuxBozo 