### PR TITLE
Center the Login.gov login button content

### DIFF
--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -75,7 +75,7 @@
                             class="col col-xs-20 col-xs-push-2 offset-4">
                             <!-- OAuth: Login.gov (Moved to top) -->
                             <a href="" th:href="${oauthLink.key}"
-                                class="saml-login-link btn--block btn--l color-blue text-left">
+                                class="saml-login-link btn--block btn--l color-blue text-center">
                                 <img class="badge--inline txt-m" alt="Login.gov icon"
                                     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAoCAYAAACfKfiZAAACdUlEQVR4Ae2XT2vTYBzHv7+nyWTgQk+ikK0dTND24vAyUEp2EsEJFb0PxIOn6SuwfQXtvHgQ1B39g/TozaIgXsSBzAlWFrvq1RqVqTPP4/MMUqoma590aS9+IA3heZrv53mS55eEINnIOmmD8yUuaJEgstDgFX2AJq7MqP1gvFx03TapcOaLl7rBAwh0RH4yf9ZI+aKCmOEDkh3jxhUmAAcjQywxGs3oA9IMI+a/wMgFDMSArP2wLl6AmZ/BnGXCW1vHxq072Gq1oAs1JwtC5w8p+yAO3FuGIffdqPAXly7De70OHbQvQVi4Yty2cfzmDRiWBR20BMZPnQwN75awz59DYgJmbqZ3nyRnQHhfsddoCXy7/6hnn9aDh9BBS4DLGfhcuR3Z/rZyXXspai9DxaFnd0OX4eMTDnSJVQmjlqHuEowloKpfFFbuKBIX2K0ODEVg39yxyDYrn0PiAmb+cGSblTuCxAXGdqmG6kZMVIDJx7DaolBleHxST0LrfUC9B3x/vtoRCW7Ibc/DL7lte19gTkxgS+eczanCJwikEZMBPkxkOlwmOJYxIuSn4ArjBqsKIhfDRo5+odkosWm33k4xKmLIMDLnd/bqx3brq4LEVQwJDiqfdt+4HQFFpvm0KgTKSBgVrqY+OP6jDmRaT0pJSvwd/o9AkhJh4aECgYRsKu7J6iC0fYZiWHikgGJqs17jjOYHkSCiurzbZ8+672qRfdAH7+1CiQjXwtpCK6EctRBUPtNsVNGDvh5G6pL4KTYtXx5XevUNRt1P+E5/aLJpO46sGXI2hKOOgxlQwT6hvOA26tBAW6BbhBNfXGMfM3GCA34DQkjcwWC8InwAAAAASUVORK5CYII=" />
                                 <span class="txt-m">Sign in with Login.gov</span>


### PR DESCRIPTION
## Context

Follow-up to #61. The Login.gov button (moved to the top of the login page) rendered its icon and label left-justified. This centers the button content.

## Change

- `jobs/uaa-customized/templates/web/login.html`: change the Login.gov `saml-login-link` anchor class from `text-left` to `text-center` so the icon + "Sign in with Login.gov" label are centered within the full-width button.

## Verification

- Diff vs `main` is a single-line class change (`text-left` -> `text-center`).
- Visual: render the login page and confirm the Login.gov button content is centered. Note: the icon uses the `badge--inline` class; if the stylesheet floats/positions it, `text-center` alone may not fully center it.

## Rollback

Revert the single-line class change back to `text-left`.

## Security Impact

None. Presentation-only CSS class change; no auth, authorization, data handling, or attack-surface impact.